### PR TITLE
Expose `staticLibDeps` to `mkPackage`

### DIFF
--- a/lake.nix
+++ b/lake.nix
@@ -27,6 +27,8 @@
     roots ? null,
     # Default dependencies
     deps ? with pkgs.lean; [Init Std Lean],
+    # Static library dependencies
+    staticLibDeps ? null,
   }: let
     manifest = importLakeManifest manifestFile;
     # Build all dependencies using `buildLeanPackage`
@@ -40,7 +42,10 @@
         then [(capitalize manifest.name)]
         else roots;
       deps = deps ++ manifestDeps;
-
+      staticLibDeps =
+        if builtins.isNull staticLibDeps
+        then []
+        else staticLibDeps;
       # Fixes some symbol not found errors
       groupStaticLibs = true;
     };


### PR DESCRIPTION
This enables users of the `mkPackage` function to include and link to static library dependencies without having to create a separate Lean package for external Lean deps and static libs.

Closes #8 as manually linking static libraries appears to be the intended behavior, but using dynlibs would add unnecessary complexity with no benefit to non-Nix users