### PR TITLE
ci: Cache on MacOS aarch64-darwin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-# Build, test, and upload Lean binaries to Cachix cache
+# Build, test, and upload Lean binaries to Cachix cache for x86_64-linux and aarch64-darwin
 name: Nix CI
 
 on:
@@ -14,7 +14,10 @@ concurrency:
 jobs:
   build:
     name: Build and cache lean4-nix
-    runs-on: warp-ubuntu-latest-x64-16x
+    strategy:
+      matrix:
+        os: [warp-ubuntu-latest-x64-16x, warp-macos-latest-arm64-6x]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v31
@@ -30,10 +33,11 @@ jobs:
   test:
     name: Test templates
     needs: build
-    runs-on: ubuntu-latest
     strategy:
       matrix:
+        os: [ubuntu-latest, warp-macos-latest-arm64-6x]
         template: [minimal, dependency, ffi-rust]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v31

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,14 @@ jobs:
           name: argumentcomputer
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
           skipPush: true
+      - name: Set sed in-place argument for MacOS
+        run: |
+          if [[ "${{ matrix.os }}" == "warp-macos-latest-arm64-6x" ]]; then
+            echo "SED_ARG=-i ''" | tee -a $GITHUB_ENV
+          else
+            echo "SED_ARG=-i" | tee -a $GITHUB_ENV
+          fi
       - run: |
-          sed -i '/lean4-nix = {/,/};/s|url = "github:[^"]*"|url = "path:../.."|' flake.nix
+          sed ${{ env.SED_ARG }} '/lean4-nix = {/,/};/s|url = "github:[^"]*"|url = "path:../.."|' flake.nix
           nix run
         working-directory: ${{ github.workspace }}/templates/${{ matrix.template }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,7 @@ jobs:
     name: Build and cache lean4-nix
     strategy:
       matrix:
-        #os: [warp-ubuntu-latest-x64-16x, warp-macos-latest-arm64-6x]
-        os: [warp-ubuntu-latest-x64-16x]
+        os: [warp-ubuntu-latest-x64-16x, warp-macos-latest-arm64-6x]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -36,8 +35,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        #os: [ubuntu-latest, warp-macos-latest-arm64-6x]
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, warp-macos-latest-arm64-6x]
         template: [minimal, dependency, ffi-rust]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,6 @@ jobs:
         with:
           name: argumentcomputer
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-      - run: nix flake update
       - run: nix build .#cacheRoots
 
   test:
@@ -62,6 +61,7 @@ jobs:
       - run: |
           sed ${{ env.SED_ARG }} '/lean4-nix = {/,/};/s|url = "github:[^"]*"|url = "path:../.."|' flake.nix
           head -n 20 flake.nix
+          nix flake update lean4-nix
         working-directory: ${{ github.workspace }}/templates/${{ matrix.template }}
       - run: nix run
         working-directory: ${{ github.workspace }}/templates/${{ matrix.template }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,8 @@ jobs:
     name: Build and cache lean4-nix
     strategy:
       matrix:
-        os: [warp-ubuntu-latest-x64-16x, warp-macos-latest-arm64-6x]
+        #os: [warp-ubuntu-latest-x64-16x, warp-macos-latest-arm64-6x]
+        os: [warp-ubuntu-latest-x64-16x]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -28,6 +29,7 @@ jobs:
         with:
           name: argumentcomputer
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - run: nix flake update
       - run: nix build .#cacheRoots
 
   test:
@@ -35,7 +37,8 @@ jobs:
     needs: build
     strategy:
       matrix:
-        os: [ubuntu-latest, warp-macos-latest-arm64-6x]
+        #os: [ubuntu-latest, warp-macos-latest-arm64-6x]
+        os: [ubuntu-latest]
         template: [minimal, dependency, ffi-rust]
     runs-on: ${{ matrix.os }}
     steps:
@@ -58,5 +61,7 @@ jobs:
           fi
       - run: |
           sed ${{ env.SED_ARG }} '/lean4-nix = {/,/};/s|url = "github:[^"]*"|url = "path:../.."|' flake.nix
-          nix run
+          head -n 20 flake.nix
+        working-directory: ${{ github.workspace }}/templates/${{ matrix.template }}
+      - run: nix run
         working-directory: ${{ github.workspace }}/templates/${{ matrix.template }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 **/result*
 **/.lake
 **/target
-templates/**/flake.lock

--- a/lake.nix
+++ b/lake.nix
@@ -28,7 +28,7 @@
     # Default dependencies
     deps ? with pkgs.lean; [Init Std Lean],
     # Static library dependencies
-    staticLibDeps ? null,
+    staticLibDeps ? [],
   }: let
     manifest = importLakeManifest manifestFile;
     # Build all dependencies using `buildLeanPackage`
@@ -36,16 +36,12 @@
   in
     pkgs.lean.buildLeanPackage {
       inherit (manifest) name;
-      inherit src;
+      inherit src staticLibDeps;
       roots =
         if builtins.isNull roots
         then [(capitalize manifest.name)]
         else roots;
       deps = deps ++ manifestDeps;
-      staticLibDeps =
-        if builtins.isNull staticLibDeps
-        then []
-        else staticLibDeps;
       # Fixes some symbol not found errors
       groupStaticLibs = true;
     };

--- a/templates/dependency/flake.lock
+++ b/templates/dependency/flake.lock
@@ -1,0 +1,130 @@
+{
+  "nodes": {
+    "blake3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1740677543,
+        "narHash": "sha256-YJ3rRzpmF6oS8p377CEoRteARCD1lr/L7/fbN5poUXw=",
+        "owner": "BLAKE3-team",
+        "repo": "BLAKE3",
+        "rev": "0f9dc2706f931366632a378a95b348e3cb40ed01",
+        "type": "github"
+      },
+      "original": {
+        "owner": "BLAKE3-team",
+        "ref": "refs/tags/1.6.1",
+        "repo": "BLAKE3",
+        "type": "github"
+      }
+    },
+    "blake3-lean": {
+      "inputs": {
+        "blake3": "blake3",
+        "flake-parts": [
+          "flake-parts"
+        ],
+        "lean4-nix": [
+          "lean4-nix"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1745970780,
+        "narHash": "sha256-ZxVOVud6/fJXTBEddAhh2x9wThz2giRUN41qje/4KS4=",
+        "owner": "argumentcomputer",
+        "repo": "Blake3.lean",
+        "rev": "0e60b1d263d5a1c08f95b5470e4e160fc5754eee",
+        "type": "github"
+      },
+      "original": {
+        "owner": "argumentcomputer",
+        "repo": "Blake3.lean",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1743550720,
+        "narHash": "sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "c621e8422220273271f52058f618c94e405bb0f5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "lean4-nix": {
+      "inputs": {
+        "flake-parts": [
+          "flake-parts"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1744206621,
+        "narHash": "sha256-17kctQIIENhliHEQzzM06OlzrF4uyq6w7KOXSeNbZc4=",
+        "owner": "argumentcomputer",
+        "repo": "lean4-nix",
+        "rev": "f798c4f818301c3dd3f5ffa1b667f824b72921a4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "argumentcomputer",
+        "repo": "lean4-nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1743964447,
+        "narHash": "sha256-nEo1t3Q0F+0jQ36HJfbJtiRU4OI+/0jX/iITURKe3EE=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "063dece00c5a77e4a0ea24e5e5a5bd75232806f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1743296961,
+        "narHash": "sha256-b1EdN3cULCqtorQ4QeWgLMrd5ZGOjLSLemfa00heasc=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "e4822aea2a6d1cdd36653c134cacfd64c97ff4fa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "blake3-lean": "blake3-lean",
+        "flake-parts": "flake-parts",
+        "lean4-nix": "lean4-nix",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/templates/dependency/flake.nix
+++ b/templates/dependency/flake.nix
@@ -7,10 +7,13 @@
     lean4-nix = {
       url = "github:argumentcomputer/lean4-nix";
       inputs.nixpkgs.follows = "nixpkgs";
+      inputs.flake-parts.follows = "flake-parts";
     };
     blake3-lean = {
       url = "github:argumentcomputer/Blake3.lean";
+      inputs.lean4-nix.follows = "lean4-nix";
       inputs.nixpkgs.follows = "nixpkgs";
+      inputs.flake-parts.follows = "flake-parts";
     };
   };
 

--- a/templates/ffi-rust/flake.lock
+++ b/templates/ffi-rust/flake.lock
@@ -1,0 +1,140 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1747260204,
+        "narHash": "sha256-KUb6MFWc2DYeTCmcEkrBrrqhxAgO6NHZh5qQKwsjG6I=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "7f85510df37247c86a0c44032f49aa18292ee11f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1747291057,
+        "narHash": "sha256-9Wir6aLJAeJKqdoQUiwfKdBn7SyNXTJGRSscRyVOo2Y=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "76ffc1b7b3ec8078fe01794628b6abff35cbda8f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1743550720,
+        "narHash": "sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "c621e8422220273271f52058f618c94e405bb0f5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "lean4-nix": {
+      "inputs": {
+        "flake-parts": [
+          "flake-parts"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1744206621,
+        "narHash": "sha256-17kctQIIENhliHEQzzM06OlzrF4uyq6w7KOXSeNbZc4=",
+        "owner": "argumentcomputer",
+        "repo": "lean4-nix",
+        "rev": "f798c4f818301c3dd3f5ffa1b667f824b72921a4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "argumentcomputer",
+        "repo": "lean4-nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1743964447,
+        "narHash": "sha256-nEo1t3Q0F+0jQ36HJfbJtiRU4OI+/0jX/iITURKe3EE=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "063dece00c5a77e4a0ea24e5e5a5bd75232806f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1743296961,
+        "narHash": "sha256-b1EdN3cULCqtorQ4QeWgLMrd5ZGOjLSLemfa00heasc=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "e4822aea2a6d1cdd36653c134cacfd64c97ff4fa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "fenix": "fenix",
+        "flake-parts": "flake-parts",
+        "lean4-nix": "lean4-nix",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1746889290,
+        "narHash": "sha256-h3LQYZgyv2l3U7r+mcsrEOGRldaK0zJFwAAva4hV/6g=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "2bafe9d96c6734aacfd49e115f6cf61e7adc68bc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/templates/ffi-rust/flake.nix
+++ b/templates/ffi-rust/flake.nix
@@ -3,11 +3,12 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
     lean4-nix = {
       url = "github:argumentcomputer/lean4-nix";
       inputs.nixpkgs.follows = "nixpkgs";
+      inputs.flake-parts.follows = "flake-parts";
     };
-    flake-parts.url = "github:hercules-ci/flake-parts";
     fenix = {
       url = "github:nix-community/fenix";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/templates/ffi-rust/lib.nix
+++ b/templates/ffi-rust/lib.nix
@@ -38,7 +38,7 @@ let
     # Final `buildPhase` instructions
     buildSteps = buildCmd ++
     [
-      "ar rcs libffi_c.a ${builtins.concatStringsSep " " (builtins.map (file: "-o ${file}.o") cFiles)}"
+      "ar rcs libffi_c.a ${builtins.concatStringsSep " " (builtins.map (file: "${file}.o") cFiles)}"
     ];
     # Gets all header files in `./c`
     hFiles = getFiles ".h";

--- a/templates/minimal/flake.lock
+++ b/templates/minimal/flake.lock
@@ -1,0 +1,85 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1743550720,
+        "narHash": "sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "c621e8422220273271f52058f618c94e405bb0f5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "lean4-nix": {
+      "inputs": {
+        "flake-parts": [
+          "flake-parts"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1744206621,
+        "narHash": "sha256-17kctQIIENhliHEQzzM06OlzrF4uyq6w7KOXSeNbZc4=",
+        "owner": "argumentcomputer",
+        "repo": "lean4-nix",
+        "rev": "f798c4f818301c3dd3f5ffa1b667f824b72921a4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "argumentcomputer",
+        "repo": "lean4-nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1743964447,
+        "narHash": "sha256-nEo1t3Q0F+0jQ36HJfbJtiRU4OI+/0jX/iITURKe3EE=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "063dece00c5a77e4a0ea24e5e5a5bd75232806f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1743296961,
+        "narHash": "sha256-b1EdN3cULCqtorQ4QeWgLMrd5ZGOjLSLemfa00heasc=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "e4822aea2a6d1cdd36653c134cacfd64c97ff4fa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "lean4-nix": "lean4-nix",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/templates/minimal/flake.nix
+++ b/templates/minimal/flake.nix
@@ -7,6 +7,7 @@
     lean4-nix = {
       url = "github:argumentcomputer/lean4-nix";
       inputs.nixpkgs.follows = "nixpkgs";
+      inputs.flake-parts.follows = "flake-parts";
     };
   };
 


### PR DESCRIPTION
This PR enables MacOS users to use the cached Lean toolchain with Nix. Also improves the reproducibility of template tests by pinning the `flake.lock` to the same inputs as the base lean4-nix, which ensures usage of the correct cached Lean build.