### PR TITLE
ci: Fix the repo-sync workflow

### DIFF
--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -6,23 +6,19 @@ on:
   - cron:  "0 0 * * *"
   workflow_dispatch:
 
+# The sync authenticates with a GitHub App installation token, so the job needs
+# nothing from `secrets.GITHUB_TOKEN`.
+permissions: {}
+
 jobs:
   repo-sync:
     name: Sync upstream changes
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-      - uses: tibdex/github-app-token@v2
-        id: generate-token
-        with:
-          app_id: ${{ secrets.TOKEN_APP_ID }}
-          private_key: ${{ secrets.TOKEN_APP_PRIVATE_KEY }}
-      - name: repo-sync
-        uses: repo-sync/github-sync@v2
-        with:
-          source_repo: "https://github.com/lenianiva/lean4-nix"
-          source_branch: "main"
-          destination_branch: "main"
-          github_token: ${{ steps.generate-token.outputs.token }}
+    uses: argumentcomputer/ci-workflows/.github/workflows/repo-sync.yml@main
+    with:
+      repository: lenianiva/lean4-nix
+      # This fork's default branch is `dev`; `main` is kept as a plain mirror
+      # of upstream, so both sides of the sync share the branch name.
+      branch: main
+    secrets:
+      TOKEN_APP_ID: ${{ secrets.TOKEN_APP_ID }}
+      TOKEN_APP_PRIVATE_KEY: ${{ secrets.TOKEN_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Replace the inline `repo-sync/github-sync` step with a call to `argumentcomputer/ci-workflows/.github/workflows/repo-sync.yml`, so this repo tracks the org's shared implementation rather than its own copy.

The shared workflow drops the third-party action for `gh repo sync` and replaces the deprecated `tibdex/github-app-token` with `actions/create-github-app-token`, requesting only the contents and workflows scopes the sync needs.